### PR TITLE
setup.pyの必須ライブラリの指定方法の修正

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
         "Topic :: Utilities",
     ],
     packages=["pybacklog"],
-    requires=["requests"],
+    install_requires=["requests"],
 )


### PR DESCRIPTION
http://python-packaging.readthedocs.io/en/latest/dependencies.html

途中で仕様が変わったのかもしれませんが、必須であるはずの`requests`がインストールされておりませんでした。
`setup.py`での指定方法が違っているのでそれの修正です。