### PR TITLE
wiki関連の情報取得メソッドの追加

### DIFF
--- a/pybacklog/__init__.py
+++ b/pybacklog/__init__.py
@@ -248,7 +248,21 @@ class BacklogClient(object):
         client.wiki(3)
         """
         return self.do("GET", "wikis/{wiki_id}", url_params={"wiki_id": wiki_id})
-        
+
+    def wiki_update_history(self, wiki_id):
+        """
+        client = BacklogClient("your_space_name", "your_api_key")
+        client.wiki_update_history(3)
+        """
+        return self.do("GET", "wikis/{wiki_id}/history", url_params={"wiki_id": wiki_id})
+
+    def wiki_stars(self, wiki_id):
+        """
+        client = BacklogClient("your_space_name", "your_api_key")
+        client.wiki_stars(3)
+        """
+        return self.do("GET", "wikis/{wiki_id}/stars", url_params={"wiki_id": wiki_id})
+
     # -------------------------------
     # extra utilities (PR welcome)
     # -------------------------------

--- a/pybacklog/__init__.py
+++ b/pybacklog/__init__.py
@@ -249,10 +249,10 @@ class BacklogClient(object):
         """
         return self.do("GET", "wikis/{wiki_id}", url_params={"wiki_id": wiki_id})
 
-    def wiki_update_history(self, wiki_id):
+    def wiki_history(self, wiki_id):
         """
         client = BacklogClient("your_space_name", "your_api_key")
-        client.wiki_update_history(3)
+        client.wiki_history(3)
         """
         return self.do("GET", "wikis/{wiki_id}/history", url_params={"wiki_id": wiki_id})
 

--- a/pybacklog/__init__.py
+++ b/pybacklog/__init__.py
@@ -234,13 +234,13 @@ class BacklogClient(object):
         return self.do("POST", "stars",
                        query_params=query_params)
 
-    def wikis(self, extra_query_params={}):
+    def wikis(self, project_id_or_key):
         """
         client = BacklogClient("your_space_name", "your_api_key")
-        client.wikis({"projectIdOrKey": 3})
+        client.wikis(3)
         """
         return self.do("GET", "wikis",
-                       query_params=extra_query_params)
+                       query_params={"projectIdOrKey": project_id_or_key})
 
     def wiki(self, wiki_id):
         """

--- a/pybacklog/__init__.py
+++ b/pybacklog/__init__.py
@@ -234,6 +234,21 @@ class BacklogClient(object):
         return self.do("POST", "stars",
                        query_params=query_params)
 
+    def wikis(self, extra_query_params={}):
+        """
+        client = BacklogClient("your_space_name", "your_api_key")
+        client.wikis({"projectIdOrKey": 3})
+        """
+        return self.do("GET", "wikis",
+                       query_params=extra_query_params)
+
+    def wiki(self, wiki_id):
+        """
+        client = BacklogClient("your_space_name", "your_api_key")
+        client.wiki(3)
+        """
+        return self.do("GET", "wikis/{wiki_id}", url_params={"wiki_id": wiki_id})
+        
     # -------------------------------
     # extra utilities (PR welcome)
     # -------------------------------


### PR DESCRIPTION
wikiの関連の以下に該当するメソッドを実装しました
(自前の環境で動作確認までできています)

https://developer.nulab-inc.com/ja/docs/backlog/api/2/get-wiki-page-list/
https://developer.nulab-inc.com/ja/docs/backlog/api/2/get-wiki-page/
https://developer.nulab-inc.com/ja/docs/backlog/api/2/get-wiki-page-history/
https://developer.nulab-inc.com/ja/docs/backlog/api/2/get-wiki-page-star/
