### PR TITLE
update domain for change jp to com.

### DIFF
--- a/pybacklog/__init__.py
+++ b/pybacklog/__init__.py
@@ -9,7 +9,7 @@ class BacklogClient(object):
     def __init__(self, space_name, api_key):
         self.space_name = space_name
         self.api_key = api_key
-        self.endpoint = "https://%s.backlog.jp/api/v2/{path}" % space_name
+        self.endpoint = "https://%s.backlog.com/api/v2/{path}" % space_name
 
     def do(self, method, url, url_params={}, query_params={}, request_params={}):
         """


### PR DESCRIPTION
https://backlog.com/ja/blog/backlog-jp-change-domain-backlog-com/

long-time backlog use's space domain is ```.jp```, but new backlog user space domain is ```.com```.

I confirmed that to happen **Not Found Space** error when access to xxxx.backlog.jp space by pybacklog.
